### PR TITLE
added sorting by multiple keys; replaced Outlook API provided sort wi…

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -8,15 +8,15 @@ var config_data = {
     // Name: Name of the task folder
     // Title: Task lane title
     // Limit: hard limits for each task lane. 0 = no limit
-    // Sort: Sort order for tasks (default = priority)
+    // Sort: Sort order for tasks (default = priority), can state multiple sort keys separated by comma, use '-' to sort descending, Example "duedate,-priority,subject"
     // Restrict: Restrict certain tasks (default = only show incomplete tasks) (More info = https://msdn.microsoft.com/en-us/library/office/ff869597.aspx)
     // Owner: If the task folder is shared by someone else, enter the name of the owner. (i.e. Evren Varol)
-    'BACKLOG_FOLDER':       { Name: '', Title: 'BACKLOG', Limit: 0, Sort: "[Importance]", Restrict: "[Complete] = false", Owner: '' },
-    'INPROGRESS_FOLDER': 	{ Name: 'InProgress', Title: 'IN PROGRESS', Limit: 5, Sort: "[Importance]", Restrict: "[Complete] = false", Owner: ''},
-    'NEXT_FOLDER': 			{ Name: 'Next', Title: 'NEXT', Limit: 0, Sort: "[DueDate][Importance]", Restrict: "[Complete] = false", Owner: ''},
-    'FOCUS_FOLDER': 		{ Name: 'Focus', Title: 'FOCUS', Limit: 0, Sort: "[Importance]", Restrict: "[Complete] = false", Owner: '' },
-    'WAITING_FOLDER': 		{ Name: 'Waiting', Title: 'WAITING', Limit: 0, Sort: "[Importance]", Restrict: "[Complete] = false", Owner: '' },
-    'COMPLETED_FOLDER':     { Name: 'Completed', Title: 'COMPLETED', Limit: 0, Sort: "[Importance]", Restrict: "[Complete] = false", Owner: '' },
+    'BACKLOG_FOLDER':       { Name: '', Title: 'BACKLOG', Limit: 0, Sort: "-priority", Restrict: "[Complete] = false", Owner: '' },
+    'INPROGRESS_FOLDER': 	{ Name: 'InProgress', Title: 'IN PROGRESS', Limit: 5, Sort: "-priority", Restrict: "[Complete] = false", Owner: ''},
+    'NEXT_FOLDER': 			{ Name: 'Next', Title: 'NEXT', Limit: 0, Sort: "duedate,-priority", Restrict: "[Complete] = false", Owner: ''},
+    'FOCUS_FOLDER': 		{ Name: 'Focus', Title: 'FOCUS', Limit: 0, Sort: "-priority", Restrict: "[Complete] = false", Owner: '' },
+    'WAITING_FOLDER': 		{ Name: 'Waiting', Title: 'WAITING', Limit: 0, Sort: "-priority", Restrict: "[Complete] = false", Owner: '' },
+    'COMPLETED_FOLDER':     { Name: 'Completed', Title: 'COMPLETED', Limit: 0, Sort: "-priority", Restrict: "[Complete] = false", Owner: '' },
 
     // Task Note Excerpt Size
     // number of chars for each task note


### PR DESCRIPTION
…th JS implementation

Here's my shot at providing sorting by multiple keys as requested in issue no #11 

Outlook's Sort implementation was not up to the task. While it can sort by multiple keys by simply concatenating them (undocumented feature BTW), you can only globally chose the direction to sort. As properties of a task have differing "natural ordering" (e.g. subject ascending, priority descending) I had to replace it to get the required behavior.

The configuration format has also changed in the process. Since the sort feature was introduced only recently, I felt it was OK to do the breaking change, and not care for backwards compatibility.

The keys available for sorting are the properties as defined when the TaskItems are transferred over to the sorted array. i.e.:

- entryID
- subject
- priority
- startdate
- duedate
- sensitivity
- categories
- notes
- status
- oneNoteTaskID
- oneNoteURL

Default sort order for each key is ascending. Prefixing a key with '-' will sort in descending order for that key (only). I have adjusted config.js so that the behavior is as before, but based on the new configuration scheme.