### PR TITLE
Set footer background color of task objects according to task categories in Outlook

### DIFF
--- a/css/taskboard.css
+++ b/css/taskboard.css
@@ -86,34 +86,28 @@ li.task.task-completed {
 }
 
 /* Color codes from: https://apple.stackexchange.com/a/96061 */
-li.task.task-red{
+footer.task-red{
     background-color: #E7A1A2;
-    border: 1px solid #E7A1A2;
 }
 
-li.task.task-orange{
+footer.task-orange{
     background-color: #F9BA89;
-    border: 1px solid #F9BA89;
 }
 
-li.task.task-yellow{
+footer.task-yellow{
     background-color: #FCFA90;
-    border: 1px solid #FCFA90;
 }
 
-li.task.task-green{
+footer.task-green{
     background-color: #78D168;
-    border: 1px solid #78D168;
 }
 
-li.task.task-blue{
+footer.task-blue{
     background-color: #9DB7E8;
-    border: 1px solid #9DB7E8;
 }
 
-li.task.task-purple{
+footer.task-purple{
     background-color: #B5A1E2;
-    border: 1px solid #B5A1E2;
 }
 
 /* blue

--- a/css/taskboard.css
+++ b/css/taskboard.css
@@ -85,34 +85,35 @@ li.task.task-completed {
     border: 1px solid #bbb;
 }
 
-li.task.task-yellow{
-    background-color: #FFFFDD;
-    border: 1px solid #EEEEA0;
+/* Color codes from: https://apple.stackexchange.com/a/96061 */
+li.task.task-red{
+    background-color: #E7A1A2;
+    border: 1px solid #E7A1A2;
 }
 
 li.task.task-orange{
-    background-color: #FFEEDD;
-    border: 1px solid #FFEEA8;
+    background-color: #F9BA89;
+    border: 1px solid #F9BA89;
 }
 
-li.task.task-purple{
-    background-color: #FFDDFF;
-    border: 1px solid #FFDDA8;
-}
-
-li.task.task-blue{
-    background-color: #DDDDFF;
-    border: 1px solid #A8A8FF;
+li.task.task-yellow{
+    background-color: #FCFA90;
+    border: 1px solid #FCFA90;
 }
 
 li.task.task-green{
-    background-color: #DDFFDD;
-    border: 1px solid #A8FFA8;
+    background-color: #78D168;
+    border: 1px solid #78D168;
 }
 
-li.task.task-red{
-    background-color: #FFDDDD;
-    border: 1px solid #FFA8A8;
+li.task.task-blue{
+    background-color: #9DB7E8;
+    border: 1px solid #9DB7E8;
+}
+
+li.task.task-purple{
+    background-color: #B5A1E2;
+    border: 1px solid #B5A1E2;
 }
 
 /* blue

--- a/css/taskboard.css
+++ b/css/taskboard.css
@@ -94,6 +94,10 @@ footer.task-orange{
     background-color: #F9BA89;
 }
 
+footer.task-peach{
+    background-color: #F7DD8F;
+}
+
 footer.task-yellow{
     background-color: #FCFA90;
 }
@@ -102,12 +106,89 @@ footer.task-green{
     background-color: #78D168;
 }
 
+footer.task-teal{
+    background-color: #9FDCC9;
+}
+
+footer.task-olive{
+    background-color: #C6D2B0;
+}
+
 footer.task-blue{
     background-color: #9DB7E8;
 }
 
 footer.task-purple{
     background-color: #B5A1E2;
+}
+
+footer.task-maroon{
+    background-color: #DAAEC2;
+}
+
+footer.task-steel{
+    background-color: #DAD9DC;
+}
+
+footer.task-darksteel{
+    background-color: #6B7994;
+}
+
+footer.task-grey{
+    background-color: #BFBFBF;
+}
+
+footer.task-darkgrey{
+    background-color: #6F6F6F;
+}
+
+footer.task-black{
+    background-color: #4F4F4F;
+}
+
+footer.task-darkred{
+    background-color: #C11A25;
+}
+
+footer.task-darkorange{
+    background-color: #E2620D;
+}
+
+footer.task-darkpeach{
+    background-color: #C79930;
+}
+
+footer.task-darkyellow{
+    background-color: #B9B300;
+}
+
+footer.task-darkgreen{
+    background-color: #368F2B;
+}
+
+footer.task-darkteal{
+    background-color: #329B7A;
+}
+
+footer.task-darkolive{
+    background-color: #778B45;
+}
+
+footer.task-darkblue{
+    background-color: #2858A5;
+}
+
+footer.task-darkpurple{
+    background-color: #5C3FA3;
+}
+
+footer.task-darkmaroon{
+    background-color: #93446B;
+}
+
+/* Make multi-category tasks grey */
+footer.task-multi{
+    background-color: #AFAFAF;
 }
 
 /* blue

--- a/css/taskboard.css
+++ b/css/taskboard.css
@@ -85,6 +85,36 @@ li.task.task-completed {
     border: 1px solid #bbb;
 }
 
+li.task.task-yellow{
+    background-color: #FFFFDD;
+    border: 1px solid #EEEEA0;
+}
+
+li.task.task-orange{
+    background-color: #FFEEDD;
+    border: 1px solid #FFEEA8;
+}
+
+li.task.task-purple{
+    background-color: #FFDDFF;
+    border: 1px solid #FFDDA8;
+}
+
+li.task.task-blue{
+    background-color: #DDDDFF;
+    border: 1px solid #A8A8FF;
+}
+
+li.task.task-green{
+    background-color: #DDFFDD;
+    border: 1px solid #A8FFA8;
+}
+
+li.task.task-red{
+    background-color: #FFDDDD;
+    border: 1px solid #FFA8A8;
+}
+
 /* blue
 header: #BBDAFF;
 body: #DBEBFF;

--- a/js/app.js
+++ b/js/app.js
@@ -97,6 +97,8 @@ tbApp.controller('taskboardController', function ($scope, GENERAL_CONFIG) {
 
                 }
         };
+        
+        $scope.categoryColors = getCategoryColors();
     };
 
     var getOutlookFolder = function (folderpath, owner) {
@@ -184,6 +186,19 @@ tbApp.controller('taskboardController', function ($scope, GENERAL_CONFIG) {
             var sortedTasks = array.sort(fieldSorter(sortKeys));
 
             return sortedTasks;
+    };
+    
+    var getCategoryColors = function() {
+        var olCategories = outlookNS.Categories();
+        var catDict = {};
+        
+        for (var i = 0; i < olCategories.Count(); i++) {
+            var color = olCategories.Item(i+1).Color();
+            var name = olCategories.Item(i+1).Name();
+            catDict[name] = color;
+        }
+        
+        return catDict;
     };
 
     // this is only a proof-of-concept single page report in a draft email for weekly report
@@ -450,7 +465,101 @@ tbApp.controller('taskboardController', function ($scope, GENERAL_CONFIG) {
         }
         return false;
     }
-
-
+    
+    $scope.footerClass = function(categories) {  
+        var taskCategories = categories.split("; ");        
+        // var olCategories = outlookNS.Categories();
+        var catColors = [];
+        
+        for (var i = 0; i < taskCategories.length; i++) {
+            // ...
+            catColors[i] = $scope.categoryColors[taskCategories[i]];
+        }
+        
+        if (catColors.length > 1) {
+            var taskClass = 'task-multi';
+        }
+        else {
+            switch (catColors[0]){
+                case 1:
+                    taskClass = 'task-red';
+                    break;
+                case 2:
+                    taskClass = 'task-orange';
+                    break;
+                case 3:
+                    taskClass = 'task-peach';
+                    break;
+                case 4:
+                    taskClass = 'task-yellow';
+                    break;
+                case 5:
+                    taskClass = 'task-green';
+                    break;
+                case 6:
+                    taskClass = 'task-teal';
+                    break;
+                case 7:
+                    taskClass = 'task-olive';
+                    break;
+                case 8:
+                    taskClass = 'task-blue';
+                    break;
+                case 9:
+                    taskClass = 'task-purple';
+                    break;
+                case 10:
+                    taskClass = 'task-maroon';
+                    break;
+                case 11:
+                    taskClass = 'task-steel';
+                    break;
+                case 12:
+                    taskClass = 'task-darksteel';
+                    break;
+                case 13:
+                    taskClass = 'task-grey';
+                    break;
+                case 14:
+                    taskClass = 'task-darkgrey';
+                    break;
+                case 15:
+                    taskClass = 'task-black';
+                    break;
+                case 16:
+                    taskClass = 'task-darkred';
+                    break;
+                case 17:
+                    taskClass = 'task-darkorange';
+                    break;
+                case 18:
+                    taskClass = 'task-darkpeach';
+                    break;
+                case 19:
+                    taskClass = 'task-darkyellow';
+                    break;
+                case 20:
+                    taskClass = 'task-darkgreen';
+                    break;
+                case 21:
+                    taskClass = 'task-darkteal';
+                    break;
+                case 22:
+                    taskClass = 'task-darkolive';
+                    break;
+                case 23:
+                    taskClass = 'task-darkblue';
+                    break;
+                case 24:
+                    taskClass = 'task-darkpurple';
+                    break;
+                case 25:
+                    taskClass = 'task-darkmaroon';
+                    break;
+            }
+        }        
+        
+        return taskClass;
+    }
 });
 

--- a/js/config.js
+++ b/js/config.js
@@ -27,12 +27,12 @@ var config_data = {
     'TASK_TEMPLATE':        '\r\n\r\n### TODO:\r\n\r\n\r\n\r\n### STATUS:\r\n\r\n\r\n\r\n### ISSUES:\r\n\r\n\r\n\r\n### REFERENCE:\r\n\r\n\r\n\r\n',
 
     // Task categories
-    'TASK_YELLOW_NAME':     'Gelbe Kategorie',
-    'TASK_BLUE_NAME':       'Blaue Kategorie',
-    'TASK_RED_NAME':        'Rote Kategorie',
-    'TASK_ORANGE_NAME':     'Orangefarbene Kategorie',
-    'TASK_PURPLE_NAME':     'Lila Kategorie',
-    'TASK_GREEN_NAME':      'Grüne Kategorie'
+    'TASK_YELLOW_NAME':     'Yellow category',
+    'TASK_BLUE_NAME':       'Blue category',
+    'TASK_RED_NAME':        'Red category',
+    'TASK_ORANGE_NAME':     'Orange category',
+    'TASK_PURPLE_NAME':     'Purple category',
+    'TASK_GREEN_NAME':      'Green categoryy'
   }
 };
 

--- a/js/config.js
+++ b/js/config.js
@@ -27,12 +27,12 @@ var config_data = {
     'TASK_TEMPLATE':        '\r\n\r\n### TODO:\r\n\r\n\r\n\r\n### STATUS:\r\n\r\n\r\n\r\n### ISSUES:\r\n\r\n\r\n\r\n### REFERENCE:\r\n\r\n\r\n\r\n',
 
     // Task categories
-    'TASK_YELLOW_NAME':     'Yellow category',
-    'TASK_BLUE_NAME':       'Blue category',
-    'TASK_RED_NAME':        'Red category',
-    'TASK_ORANGE_NAME':     'Orange category',
-    'TASK_PURPLE_NAME':     'Purple category',
-    'TASK_GREEN_NAME':      'Green categoryy'
+    'TASK_YELLOW_NAME':     'Yellow Category',
+    'TASK_BLUE_NAME':       'Blue Category',
+    'TASK_RED_NAME':        'Red Category',
+    'TASK_ORANGE_NAME':     'Orange Category',
+    'TASK_PURPLE_NAME':     'Purple Category',
+    'TASK_GREEN_NAME':      'Green Category'
   }
 };
 

--- a/js/config.js
+++ b/js/config.js
@@ -24,8 +24,15 @@ var config_data = {
     'TASKNOTE_EXCERPT':		200,
 
     // Default task template
-    'TASK_TEMPLATE':        '\r\n\r\n### TODO:\r\n\r\n\r\n\r\n### STATUS:\r\n\r\n\r\n\r\n### ISSUES:\r\n\r\n\r\n\r\n### REFERENCE:\r\n\r\n\r\n\r\n'
+    'TASK_TEMPLATE':        '\r\n\r\n### TODO:\r\n\r\n\r\n\r\n### STATUS:\r\n\r\n\r\n\r\n### ISSUES:\r\n\r\n\r\n\r\n### REFERENCE:\r\n\r\n\r\n\r\n',
 
+    // Task categories
+    'TASK_YELLOW_NAME':     'Gelbe Kategorie',
+    'TASK_BLUE_NAME':       'Blaue Kategorie',
+    'TASK_RED_NAME':        'Rote Kategorie',
+    'TASK_ORANGE_NAME':     'Orangefarbene Kategorie',
+    'TASK_PURPLE_NAME':     'Lila Kategorie',
+    'TASK_GREEN_NAME':      'Grüne Kategorie'
   }
 };
 

--- a/js/config.js
+++ b/js/config.js
@@ -25,14 +25,6 @@ var config_data = {
 
     // Default task template
     'TASK_TEMPLATE':        '\r\n\r\n### TODO:\r\n\r\n\r\n\r\n### STATUS:\r\n\r\n\r\n\r\n### ISSUES:\r\n\r\n\r\n\r\n### REFERENCE:\r\n\r\n\r\n\r\n',
-
-    // Task categories
-    'TASK_YELLOW_NAME':     'Yellow Category',
-    'TASK_BLUE_NAME':       'Blue Category',
-    'TASK_RED_NAME':        'Red Category',
-    'TASK_ORANGE_NAME':     'Orange Category',
-    'TASK_PURPLE_NAME':     'Purple Category',
-    'TASK_GREEN_NAME':      'Green Category'
   }
 };
 

--- a/kanban-ie.html
+++ b/kanban-ie.html
@@ -65,8 +65,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -98,8 +97,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -131,8 +129,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -166,8 +163,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -199,8 +195,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>

--- a/kanban-ie.html
+++ b/kanban-ie.html
@@ -59,7 +59,10 @@
                         </h5>
                     </header>
                     <ul id="backlogList" ui-sortable="sortableOptions" ng-model="backlogTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -91,7 +94,10 @@
                         </h5>
                     </header>
                     <ul id="nextList" ui-sortable="sortableOptions" ng-model="nextTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -123,7 +129,10 @@
                         </h5>
                     </header>
                     <ul id="inprogressList" ui-sortable="sortableOptions" ng-model="inprogressTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -157,7 +166,10 @@
                         </h5>
                     </header>
                     <ul id="focusList" ui-sortable="sortableOptions" ng-model="focusTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -189,7 +201,10 @@
                         </h5>
                     </header>
                     <ul id="waitingList" ui-sortable="sortableOptions" ng-model="waitingTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>

--- a/kanban-ie.html
+++ b/kanban-ie.html
@@ -59,16 +59,14 @@
                         </h5>
                     </header>
                     <ul id="backlogList" ui-sortable="sortableOptions" ng-model="backlogTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -94,16 +92,14 @@
                         </h5>
                     </header>
                     <ul id="nextList" ui-sortable="sortableOptions" ng-model="nextTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -129,16 +125,14 @@
                         </h5>
                     </header>
                     <ul id="inprogressList" ui-sortable="sortableOptions" ng-model="inprogressTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -166,16 +160,14 @@
                         </h5>
                     </header>
                     <ul id="focusList" ui-sortable="sortableOptions" ng-model="focusTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -201,16 +193,14 @@
                         </h5>
                     </header>
                     <ul id="waitingList" ui-sortable="sortableOptions" ng-model="waitingTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>

--- a/kanban.html
+++ b/kanban.html
@@ -65,8 +65,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -98,8 +97,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -131,8 +129,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -166,8 +163,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -199,8 +195,7 @@
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
+                            <footer class="text-right" ng-class="footerClass(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>

--- a/kanban.html
+++ b/kanban.html
@@ -59,7 +59,10 @@
                         </h5>
                     </header>
                     <ul id="backlogList" ui-sortable="sortableOptions" ng-model="backlogTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -91,7 +94,10 @@
                         </h5>
                     </header>
                     <ul id="nextList" ui-sortable="sortableOptions" ng-model="nextTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -123,7 +129,10 @@
                         </h5>
                     </header>
                     <ul id="inprogressList" ui-sortable="sortableOptions" ng-model="inprogressTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -157,7 +166,10 @@
                         </h5>
                     </header>
                     <ul id="focusList" ui-sortable="sortableOptions" ng-model="focusTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
@@ -189,7 +201,10 @@
                         </h5>
                     </header>
                     <ul id="waitingList" ui-sortable="sortableOptions" ng-model="waitingTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
+                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
+                        ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>

--- a/kanban.html
+++ b/kanban.html
@@ -59,16 +59,14 @@
                         </h5>
                     </header>
                     <ul id="backlogList" ui-sortable="sortableOptions" ng-model="backlogTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in backlogTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -94,16 +92,14 @@
                         </h5>
                     </header>
                     <ul id="nextList" ui-sortable="sortableOptions" ng-model="nextTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in nextTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -129,16 +125,14 @@
                         </h5>
                     </header>
                     <ul id="inprogressList" ui-sortable="sortableOptions" ng-model="inprogressTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in inprogressTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -166,16 +160,14 @@
                         </h5>
                     </header>
                     <ul id="focusList" ui-sortable="sortableOptions" ng-model="focusTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in focusTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>
@@ -201,16 +193,14 @@
                         </h5>
                     </header>
                     <ul id="waitingList" ui-sortable="sortableOptions" ng-model="waitingTasks" class="panel-body tasklist list-unstyled">
-                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2,
-                        'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
-                        'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }"
-                        ng-dblclick="editTask(task)">
+                        <li ng-repeat="task in waitingTasks | filter:search" class="task panel" ng-class=" { 'task-low' : task.priority === 0, 'task-medium' : task.priority === 1, 'task-high' : task.priority === 2, 'task-private': task.sensitivity === 2 }" ng-dblclick="editTask(task)">
                             <header class="panel-heading">
                                 {{ task.subject }}
                                 <span ng-show="(task.duedate | date:'yyyy' ) != '4501'" ng-class="isOverdue(task.duedate)" class="pull-right">(Due: {{ task.duedate | date:'dd/MM/yy' }}) </span>
                             </header>
                             <div class="panel-body"> {{ task.notes }} </div>
-                            <footer class="text-right">
+                            <footer class="text-right" ng-class=" { 'task-yellow': task.categories.indexOf(general_config.TASK_YELLOW_NAME) !== -1, 'task-blue': task.categories.indexOf(general_config.TASK_BLUE_NAME) !== -1, 'task-red': task.categories.indexOf(general_config.TASK_RED_NAME) !== -1,
+                            'task-orange': task.categories.indexOf(general_config.TASK_ORANGE_NAME) !== -1, 'task-purple': task.categories.indexOf(general_config.TASK_PURPLE_NAME) !== -1, 'task-green': task.categories.indexOf(general_config.TASK_GREEN_NAME) !== -1 }">
                                 <div ng-if="(task.categories != '')" class="pull-left small"><span class="glyphicon glyphicon-tag"></span> {{ task.categories }}</div>
                                 <span class="btn-group btn-group-xs">
                                     <button class="btn btn-default btn-xs" aria-label="Edit" type="button" ng-click="editTask(task)"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>


### PR DESCRIPTION
When tasks are assigned a category in Outlook, the footer of the task object on the task board is colored in the corresponding color for the six pre-defined main categories. The category names can be adapted in config.js.

![image](https://user-images.githubusercontent.com/9609820/30276617-b5c02bb0-9705-11e7-8981-66021ad66f53.png)
